### PR TITLE
Add ignore_xref to generated translation module.

### DIFF
--- a/src/epo_po_template.erl
+++ b/src/epo_po_template.erl
@@ -15,6 +15,7 @@ erl() ->
 
 -record(porec2, {msgstr, msgstr_n = {}, n_max}).
 -export([get_record/2, get_idx/2]).
+-ignore_xref([get_record/2, get_idx/2]).
 ">>
 	,
 <<"get_idx(N, <<Locale2:2/binary, $_, _/binary>>) ->


### PR DESCRIPTION
xref will otherwise complain about unused exports, as these functions
are normally only called indirectly via the epo_gettext module.